### PR TITLE
disabled dependency manager by default

### DIFF
--- a/api-bungeecord/src/main/java/dev/id2r/api/bungee/BungeePlugin.java
+++ b/api-bungeecord/src/main/java/dev/id2r/api/bungee/BungeePlugin.java
@@ -4,6 +4,8 @@ import dev.id2r.api.common.dependency.DependencyManager;
 import dev.id2r.api.common.plugin.ID2RPlugin;
 import net.md_5.bungee.api.plugin.Plugin;
 
+import java.util.Optional;
+
 /**
  * Class to extend to use load your needs.
  *
@@ -13,10 +15,13 @@ public abstract class BungeePlugin extends Plugin implements ID2RPlugin {
 
     private final BungeeBootstrap bootstrap;
 
-    private final BungeeDependencyManager dependencyManager;
+    private BungeeDependencyManager dependencyManager;
 
     public BungeePlugin() {
         this.bootstrap = new BungeeBootstrap(this, this);
+    }
+
+    public final void enableDependencyManager() {
         this.dependencyManager = new BungeeDependencyManager(bootstrap);
     }
 
@@ -41,8 +46,8 @@ public abstract class BungeePlugin extends Plugin implements ID2RPlugin {
     }
 
     @Override
-    public DependencyManager getDependencyManager() {
-        return this.dependencyManager;
+    public Optional<DependencyManager> getDependencyManager() {
+        return Optional.ofNullable(this.dependencyManager);
     }
 
 }

--- a/api-common/src/main/java/dev/id2r/api/common/plugin/ID2RPlugin.java
+++ b/api-common/src/main/java/dev/id2r/api/common/plugin/ID2RPlugin.java
@@ -3,6 +3,8 @@ package dev.id2r.api.common.plugin;
 import dev.id2r.api.common.dependency.DependencyManager;
 import dev.id2r.api.common.plugin.bootstrap.ID2RPluginBootstrap;
 
+import java.util.Optional;
+
 public interface ID2RPlugin {
 
     /**
@@ -28,6 +30,6 @@ public interface ID2RPlugin {
     /**
      * Dynamic Dependency manager
      */
-    DependencyManager getDependencyManager();
+    Optional<DependencyManager> getDependencyManager();
 
 }

--- a/api-spigot/src/main/java/dev/id2r/api/spigot/plugin/SpigotPlugin.java
+++ b/api-spigot/src/main/java/dev/id2r/api/spigot/plugin/SpigotPlugin.java
@@ -5,13 +5,18 @@ import dev.id2r.api.common.plugin.ID2RPlugin;
 import dev.id2r.api.common.plugin.bootstrap.ID2RPluginBootstrap;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.Optional;
+
 public abstract class SpigotPlugin extends JavaPlugin implements ID2RPlugin {
 
     private final SpigotBootstrap bootstrap;
-    private final DependencyManager dependencyManager;
+    private DependencyManager dependencyManager;
 
     public SpigotPlugin() {
         this.bootstrap = new SpigotBootstrap(this, this);
+    }
+
+    public final void enableDependencyManager() {
         this.dependencyManager = new SpigotDependencyManager(this.bootstrap);
     }
 
@@ -36,7 +41,7 @@ public abstract class SpigotPlugin extends JavaPlugin implements ID2RPlugin {
     }
 
     @Override
-    public DependencyManager getDependencyManager() {
-        return this.dependencyManager;
+    public Optional<DependencyManager> getDependencyManager() {
+        return Optional.ofNullable(this.dependencyManager);
     }
 }

--- a/api-velocity/src/main/java/dev/id2r/api/velocity/VelocityPlugin.java
+++ b/api-velocity/src/main/java/dev/id2r/api/velocity/VelocityPlugin.java
@@ -2,25 +2,30 @@ package dev.id2r.api.velocity;
 
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
+import dev.id2r.api.common.dependency.DependencyManager;
 import dev.id2r.api.common.plugin.ID2RPlugin;
 import dev.id2r.api.common.plugin.bootstrap.ID2RPluginBootstrap;
 import org.slf4j.Logger;
 
 import java.nio.file.Path;
+import java.util.Optional;
 
 public abstract class VelocityPlugin implements ID2RPlugin {
 
     private final VelocityBootstrap bootstrap;
-    private final VelocityDependencyManager dependencyManager;
+    private VelocityDependencyManager dependencyManager;
 
     public VelocityPlugin(Logger logger, ProxyServer server, @DataDirectory Path data) {
         this.bootstrap = new VelocityBootstrap(server, logger, data, this);
+    }
+
+    public final void enableDependencyManager() {
         this.dependencyManager = new VelocityDependencyManager(this.bootstrap);
     }
 
     @Override
-    public VelocityDependencyManager getDependencyManager() {
-        return dependencyManager;
+    public Optional<DependencyManager> getDependencyManager() {
+        return Optional.ofNullable(dependencyManager);
     }
 
     @Override

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,6 @@ subprojects {
     }
 
     project.ext.major = '1'
-    project.ext.minor = '2'
+    project.ext.minor = '3'
     project.ext.apiVer = project.ext.major + '.' + project.ext.minor
 }


### PR DESCRIPTION
the reason for this is that the dependency library doesn't work in java 9+. 
the way that java 9 handles the `setAccessible` method is different than java 8.

this update is a fix for servers that uses java 9+, though it is worth noting that plugin developers should shade the libraries directly inside the jar.